### PR TITLE
Add check for zero decimal value in hash's last 16 digits

### DIFF
--- a/calc-storage-location.sh
+++ b/calc-storage-location.sh
@@ -17,6 +17,11 @@ hash=$(cast k $1)
 last_16_of_hash=${hash: -16}
 # echo "last 16-digits of hash:                                 $last_16_of_hash"
 last_16_of_hash_decimal=$((16#$last_16_of_hash))
+# Check if the last 16 digits of hash decimal is 0
+if [ "$last_16_of_hash_decimal" -eq 0 ]; then
+    echo "Error: CANNOT calculate the storage location, because the decimal value of the last 16 digits of the hash is 0. Aborting..."
+    exit 1
+fi
 # echo "last 16-digits of hash decimal:         $last_16_of_hash_decimal"
 last_16_of_hash_minus_one_decimal=$((last_16_of_hash_decimal - 1))
 # echo "last 16-digits of hash minus 1 decimal: $last_16_of_hash_minus_one_decimal"


### PR DESCRIPTION
This PR adds a crucial error check to the storage location calculation process.

It introduces a condition to abort the operation if the decimal conversion of the `hash's last 16 digits` results in 0, addressing potential hash truncation issues.

This enhancement ensures the robustness and reliability of the storage location determination, preventing errors that could arise from invalid hash processing.